### PR TITLE
Supported attribute "default" for filters "attr" and "map" to resolve #48.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@
 *.out
 *.app
 
+.*
+
 build/
 dist/
 

--- a/src/filters.cpp
+++ b/src/filters.cpp
@@ -161,13 +161,16 @@ InternalValue Sort::Filter(const InternalValue& baseVal, RenderContext& context)
 
 Attribute::Attribute(FilterParams params)
 {
-    ParseParams({{"name", true}}, params);
+    ParseParams({{"name", true}, {"default", false}}, params);
 }
 
 InternalValue Attribute::Filter(const InternalValue& baseVal, RenderContext& context)
 {
-    InternalValue attrNameVal = GetArgumentValue("name", context);
-    return Subscript(baseVal, attrNameVal);
+    const auto attrNameVal = GetArgumentValue("name", context);
+    const auto result = Subscript(baseVal, attrNameVal);
+    if (result.IsEmpty())
+      return GetArgumentValue("default", context);
+    return result;
 }
 
 Default::Default(FilterParams params)
@@ -363,21 +366,32 @@ InternalValue ApplyMacro::Filter(const InternalValue& baseVal, RenderContext& co
 
 Map::Map(FilterParams params)
 {
-    FilterParams newParams;
-
-    if (params.kwParams.size() == 1 && params.posParams.empty() && params.kwParams.count("attribute") == 1)
-    {
-        newParams.kwParams["name"] = params.kwParams["attribute"];
-        newParams.kwParams["filter"] = std::make_shared<ConstantExpression>("attr"s);
-    }
-    else
-    {
-        newParams = std::move(params);
-    }
-
-    ParseParams({{"filter", true}}, newParams);
+    ParseParams({{"filter", true}}, MakeParams(std::move(params)));
     m_mappingParams.kwParams = m_args.extraKwArgs;
     m_mappingParams.posParams = m_args.extraPosArgs;
+}
+
+FilterParams Map::MakeParams(FilterParams params)
+{
+    if (!params.posParams.empty() || params.kwParams.empty() || params.kwParams.size() > 2) {
+        return params;
+    }
+
+    const auto attributeIt = params.kwParams.find("attribute");
+    if (attributeIt == params.kwParams.cend())
+    {
+      return params;
+    }
+
+    FilterParams result;
+    result.kwParams["name"] = attributeIt->second;
+    result.kwParams["filter"] = std::make_shared<ConstantExpression>("attr"s);
+
+    const auto defaultIt = params.kwParams.find("default");
+    if (defaultIt != params.kwParams.cend())
+        result.kwParams["default"] = defaultIt->second;
+
+    return result;
 }
 
 InternalValue Map::Filter(const InternalValue& baseVal, RenderContext& context)

--- a/src/filters.h
+++ b/src/filters.h
@@ -81,6 +81,8 @@ public:
     InternalValue Filter(const InternalValue& baseVal, RenderContext& context);
 
 private:
+    static FilterParams MakeParams(FilterParams);
+
     FilterParams m_mappingParams;
 };
 

--- a/test/filters_test.cpp
+++ b/test/filters_test.cpp
@@ -238,6 +238,8 @@ INSTANTIATE_TEST_CASE_P(Unique, ListIteratorTest, ::testing::Values(
 INSTANTIATE_TEST_CASE_P(Attr, FilterGenericTest, ::testing::Values(
                             InputOutputPair{"{'key'='itemName', 'value'='itemValue'} | attr('key')", "itemName"},
                             InputOutputPair{"mapValue | attr('intVal')", "10"},
+                            InputOutputPair{"mapValue | attr('intVal', default='99')", "10"},
+                            InputOutputPair{"mapValue | attr('nonexistent', default='99')", "99"},
                             InputOutputPair{"mapValue | attr(name='dblVal')", "100.5"},
                             InputOutputPair{"mapValue | attr('stringVal')", "string100.5"},
                             InputOutputPair{"mapValue | attr('boolValue')", "true"},
@@ -247,6 +249,14 @@ INSTANTIATE_TEST_CASE_P(Attr, FilterGenericTest, ::testing::Values(
 
 INSTANTIATE_TEST_CASE_P(Map, ListIteratorTest, ::testing::Values(
                             InputOutputPair{"reflectedList | map(attribute='intValue')",       "0, 1, 2, 3, 4, 5, 6, 7, 8, 9"},
+                            InputOutputPair{"reflectedList | map(attribute='intValue', default='99')",
+                                                                                               "0, 1, 2, 3, 4, 5, 6, 7, 8, 9"},
+                            InputOutputPair{"reflectedList | map(attribute='intEvenValue')",   "0, , 2, , 4, , 6, , 8, "},
+                            InputOutputPair{"reflectedList | map(attribute='intEvenValue', default='99')",   
+                                                                                               "0, 99, 2, 99, 4, 99, 6, 99, 8, 99"},                                                                   
+                            InputOutputPair{"reflectedList | map(attribute='nonexistent')",    ", , , , , , , , , "},
+                            InputOutputPair{"reflectedList | map(attribute='nonexistent', default='99')",    
+                                                                                               "99, 99, 99, 99, 99, 99, 99, 99, 99, 99"},
                             InputOutputPair{"[[0, 1], [1, 2], [2, 3], [3, 4]] | map('first')", "0, 1, 2, 3"},
                             InputOutputPair{"[['str1', 'Str2'], ['str2', 'Str3'], ['str3', 'Str4'], ['str4', 'Str5']] | map('min')",
                                                                                                "str1, str2, str3, str4"},
@@ -377,7 +387,7 @@ INSTANTIATE_TEST_CASE_P(DictSort, FilterGenericTest, ::testing::Values(
                             InputOutputPair{"{'key'='itemName', 'Value'='ItemValue'} | dictsort(case_sensitive=true) | pprint", "['Value': 'ItemValue', 'key': 'itemName']"},
                             InputOutputPair{"{'key'='itemName', 'Value'='ItemValue'} | dictsort(case_sensitive=true, reverse=true) | pprint", "['key': 'itemName', 'Value': 'ItemValue']"},
                             InputOutputPair{"simpleMapValue | dictsort | pprint", "['boolValue': true, 'dblVal': 100.5, 'intVal': 10, 'stringVal': 'string100.5']"},
-                            InputOutputPair{"reflectedVal | dictsort | pprint", "['basicCallable': <callable>, 'boolValue': false, 'dblValue': 0, 'getInnerStruct': <callable>, 'getInnerStructValue': <callable>, 'innerStruct': {'strValue': 'Hello World!'}, 'innerStructList': [{'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}], 'intValue': 0, 'strValue': 'test string 0', 'tmpStructList': [{'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}], 'wstrValue': '<wchar_string>']"}
+                            InputOutputPair{"reflectedVal | dictsort | pprint", "['basicCallable': <callable>, 'boolValue': false, 'dblValue': 0, 'getInnerStruct': <callable>, 'getInnerStructValue': <callable>, 'innerStruct': {'strValue': 'Hello World!'}, 'innerStructList': [{'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}], 'intEvenValue': 0, 'intValue': 0, 'strValue': 'test string 0', 'tmpStructList': [{'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}], 'wstrValue': '<wchar_string>']"}
                             ));
 
 INSTANTIATE_TEST_CASE_P(UrlEncode, FilterGenericTest, ::testing::Values(

--- a/test/test_tools.h
+++ b/test/test_tools.h
@@ -214,6 +214,13 @@ struct TypeReflection<TestStruct> : TypeReflected<TestStruct>
     {
         static std::unordered_map<std::string, FieldAccessor> accessors = {
             {"intValue", [](const TestStruct& obj) {assert(obj.isAlive); return obj.intValue;}},
+            {"intEvenValue", [](const TestStruct& obj) -> Value
+             {
+                 assert(obj.isAlive);
+                 if (obj.intValue % 2)
+                    return {};
+                 return {obj.intValue};
+             }},
             {"dblValue", [](const TestStruct& obj) {assert(obj.isAlive); return obj.dblValue;}},
             {"boolValue", [](const TestStruct& obj) {assert(obj.isAlive); return obj.boolValue;}},
             {"strValue", [](const TestStruct& obj) {assert(obj.isAlive); return obj.strValue;}},

--- a/test/user_callable_test.cpp
+++ b/test/user_callable_test.cpp
@@ -315,11 +315,12 @@ INSTANTIATE_TEST_CASE_P(MapParamConvert, UserCallableParamConvertTest, ::testing
                                             "'innerStructList': [{'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, "
                                             "{'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, "
                                             "{'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, "
-                                            "{'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}], 'intValue': 0, 'strValue': 'test string 0', "
-                                            "'tmpStructList': [{'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, "
+                                            "{'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}], 'intEvenValue': 0, 'intValue': 0, "
+                                            "'strValue': 'test string 0', 'tmpStructList': [{'strValue': 'Hello World!'}, "
                                             "{'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, "
                                             "{'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, "
-                                            "{'strValue': 'Hello World!'}], 'wstrValue': '<wchar_string>']"},
+                                            "{'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}, {'strValue': 'Hello World!'}], "
+                                            "'wstrValue': '<wchar_string>']"},
                             InputOutputPair{"GMapFn(reflectedVal.innerStruct) | dictsort", "['strValue': 'Hello World!']"}
                             ));
 


### PR DESCRIPTION
Attribute "default" was required by filter "map", but as "map" uses filter "attr" for each collection entity, "default" supported for "attr" too.