### PR TITLE
Supports for escape characters in the string literals. Resolves #49.

### DIFF
--- a/src/helpers.h
+++ b/src/helpers.h
@@ -122,6 +122,55 @@ Dst ConvertString(Src&& from)
     return detail::StringConverter<std::decay_t<Src>, std::decay_t<Dst>>::DoConvert(std::forward<Src>(from));
 }
 
+//! CompileEscapes replaces escape characters by their meanings.
+/**
+ * @param[in] s Characters sequence with zero or more escape characters.
+ * @return Characters sequence copy where replaced all escape characters by
+ * their meanings.
+ */
+template<typename Sequence>
+Sequence CompileEscapes(Sequence s)
+{
+   auto itr1 = s.begin();
+   auto itr2 = s.begin();
+   const auto end = s.cend();
+
+   auto removalCount  = 0;
+
+   while (end != itr1)
+   {
+      if ('\\' == *itr1)
+      {
+         ++removalCount;
+
+         if (end == ++itr1)
+            break;
+         if ('\\' != *itr1)
+         {
+            switch (*itr1)
+            {
+               case 'n': *itr1 = '\n'; break;
+               case 'r': *itr1 = '\r'; break;
+               case 't': *itr1 = '\t'; break;
+               default:                break;
+            }
+
+            continue;
+         }
+      }
+
+      if (itr1 != itr2)
+         *itr2 = *itr1;
+
+      ++itr1;
+      ++itr2;
+   }
+
+   s.resize(s.size() - removalCount);
+
+   return s;
+}
+
 } // jinja2
 
 #endif // HELPERS_H

--- a/src/lexertk.h
+++ b/src/lexertk.h
@@ -281,50 +281,6 @@ namespace lexertk
          }
       };
 
-#if 0
-      inline void cleanup_escapes(std::string& s)
-      {
-         typedef std::string::iterator str_itr_t;
-
-         str_itr_t itr1 = s.begin();
-         str_itr_t itr2 = s.begin();
-         str_itr_t end  = s.end  ();
-
-         std::size_t removal_count  = 0;
-
-         while (end != itr1)
-         {
-            if ('\\' == (*itr1))
-            {
-               ++removal_count;
-
-               if (end == ++itr1)
-                  break;
-               else if ('\\' != (*itr1))
-               {
-                  switch (*itr1)
-                  {
-                     case 'n' : (*itr1) = '\n'; break;
-                     case 'r' : (*itr1) = '\r'; break;
-                     case 't' : (*itr1) = '\t'; break;
-                  }
-
-                  continue;
-               }
-            }
-
-            if (itr1 != itr2)
-            {
-               (*itr2) = (*itr1);
-            }
-
-            ++itr1;
-            ++itr2;
-         }
-
-         s.resize(s.size() - removal_count);
-      }
-#endif
    }
 
    struct token

--- a/src/template_parser.h
+++ b/src/template_parser.h
@@ -746,8 +746,12 @@ private:
     InternalValue GetAsValue(const CharRange& range, Token::Type type) override
     {
         if (type == Token::String)
-            return InternalValue(m_template->substr(range.startOffset, range.size()));
-        else if (type == Token::IntegerNum || type == Token::FloatNum)
+        {
+            auto rawValue = CompileEscapes(
+                m_template->substr(range.startOffset, range.size()));
+            return InternalValue(std::move(rawValue));
+        }
+        if (type == Token::IntegerNum || type == Token::FloatNum)
             return traits_t::RangeToNum(*m_template, range, type);
         return InternalValue();
     }

--- a/test/basic_tests.cpp
+++ b/test/basic_tests.cpp
@@ -456,3 +456,14 @@ from Parser!)";
 from Parser!)";
     EXPECT_STREQ(expectedResult.c_str(), result.c_str());
 }
+
+TEST(BasicTests, LiteralWithEscapeCharacters)
+{
+    Template tpl;
+    ASSERT_TRUE(tpl.Load(R"({{ 'Hello\t\nWorld\n\twith\nescape\tcharacters!' }})"));
+
+    const auto result = tpl.RenderAsString({}).value();
+    std::cout << result << std::endl;
+    const std::string expectedResult = "Hello\t\nWorld\n\twith\nescape\tcharacters!";
+    EXPECT_STREQ(expectedResult.c_str(), result.c_str());
+}

--- a/test/helpers_tests.cpp
+++ b/test/helpers_tests.cpp
@@ -1,0 +1,22 @@
+#include "gtest/gtest.h"
+
+#include "../src/helpers.h"
+
+using namespace jinja2;
+
+TEST(Helpers, CompileEscapes)
+{
+    EXPECT_STREQ("\n", CompileEscapes(std::string{"\\n"}).c_str());
+    EXPECT_STREQ("\t", CompileEscapes(std::string{"\\t"}).c_str());
+    EXPECT_STREQ("\r", CompileEscapes(std::string{"\\r"}).c_str());
+    EXPECT_STREQ("\r\n\t", CompileEscapes(std::string{R"(\r\n\t)"}).c_str());
+    EXPECT_STREQ(
+        "aa\rbb\ncc\tdd",
+        CompileEscapes(std::string{R"(aa\rbb\ncc\tdd)"}).c_str());
+    EXPECT_STREQ("", CompileEscapes(std::string{""}).c_str());
+    EXPECT_STREQ(
+        "aa bb cc dd",
+        CompileEscapes(std::string{"aa bb cc dd"}).c_str());
+}
+
+


### PR DESCRIPTION
Supported next characters: \n, \r and \t.