### PR TITLE
add CapitalMode to StringConverter::Filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ More detailed examples and features describtion can be found in the documentatio
 ## Current Jinja2 support
 Currently, Jinja2Cpp supports the limited number of Jinja2 features. By the way, Jinja2Cpp is planned to be full [jinja2 specification](http://jinja.pocoo.org/docs/2.10/templates/)-conformant. The current support is limited to:
 -  expressions. You can use almost every style of expressions: simple, filtered, conditional, and so on.
--  big number of filters (**sort, default, first, last, length, max, min, reverse, unique, sum, attr, map, reject, rejectattr, select, selectattr, pprint, dictsort, abs, float, int, list, round, random, trim, title, upper, wordcount, replace, truncate, groupby, urlencode**)
+-  big number of filters (**sort, default, first, last, length, max, min, reverse, unique, sum, attr, map, reject, rejectattr, select, selectattr, pprint, dictsort, abs, float, int, list, round, random, trim, title, upper, wordcount, replace, truncate, groupby, urlencode, capitalize**)
 -  big number of testers (**eq, defined, ge, gt, iterable, le, lt, mapping, ne, number, sequence, string, undefined, in, even, odd, lower, upper**)
 -  limited number of functions (**range**, **loop.cycle**)
 -  'if' statement (with 'elif' and 'else' branches)

--- a/src/string_converter_filter.cpp
+++ b/src/string_converter_filter.cpp
@@ -303,6 +303,21 @@ InternalValue StringConverter::Filter(const InternalValue& baseVal, RenderContex
     case UrlEncodeMode:
         result = Apply<UrlStringEncoder>(baseVal);
         break;
+    case CapitalMode:
+        result = ApplyStringConverter<GenericStringEncoder>(baseVal, [isFirstChar = true, &isAlpha](auto ch, auto&& fn) mutable {
+            if (isAlpha(ch))
+            {
+                if (isFirstChar)
+                    fn(std::toupper(ch, std::locale()));
+                else
+                    fn(std::tolower(ch, std::locale()));
+            }
+            else
+                fn(ch);
+
+            isFirstChar = false;
+        });
+        break;
     default:
         break;
     }

--- a/test/filters_test.cpp
+++ b/test/filters_test.cpp
@@ -466,3 +466,13 @@ INSTANTIATE_TEST_CASE_P(Truncate, FilterGenericTest, ::testing::Values(
                             InputOutputPair{"'VeryVeryVeryLongWord' | truncate(16) | pprint", "'VeryVeryVeryLongWord'"},
                             InputOutputPair{"'foo bar baz qux' | truncate(6, end=' >>', leeway=0) | pprint", "'foo >>'"}
                             ));
+
+INSTANTIATE_TEST_CASE_P(Capitalize, FilterGenericTest, ::testing::Values(
+                            InputOutputPair{"'String' | capitalize | pprint", "'String'"},
+                            InputOutputPair{"'string' | capitalize | pprint", "'String'"},
+                            InputOutputPair{"'1234string' | capitalize | pprint", "'1234string'"},
+                            InputOutputPair{"'1234String' | capitalize | pprint", "'1234string'"},
+                            InputOutputPair{"'Hello World' | capitalize | pprint", "'Hello world'"},
+                            InputOutputPair{"' Hello World' | capitalize | pprint", "' hello world'"},
+                            InputOutputPair{"'Hello123OOO, World!' | capitalize | pprint", "'Hello123ooo, world!'"}
+                            ));


### PR DESCRIPTION
Fixes #137 

Note that [the documentation](https://jinja.palletsprojects.com/en/2.10.x/templates/#capitalize) says
```
The first character will be uppercase, all others lowercase.
```

Here we look for the first (alphanumeric) character, pass it to `std::toupper`, then pass the remaining alphanumeric characters through `std::tolower`. Let me know if the desired behavior of the filter is different from this and I'll modify the PR accordingly.