### PR TITLE
Fix library always being generated as shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ option(JINJA2CPP_PIC "Control -fPIC option for library build" OFF)
 option(JINJA2CPP_VERBOSE "Add extra debug output to the build scripts" OFF)
 
 if (DEFINED BUILD_SHARED_LIBS)
-    set(JINJA2CPP_BUILD_SHARED BUILD_SHARED_LIBS)
+    set(JINJA2CPP_BUILD_SHARED ${BUILD_SHARED_LIBS})
 endif ()
 
 if (JINJA2CPP_BUILD_SHARED)


### PR DESCRIPTION
Use content of BUILD_SHARED_LIBS to initialize JINJA2CPP_BUILD_SHARED_LIBS