### PR TITLE
ADD include of a c++ stl file in main library to patch compiler error

### DIFF
--- a/include/jinja2cpp/template_env.h
+++ b/include/jinja2cpp/template_env.h
@@ -6,6 +6,7 @@
 #include "filesystem_handler.h"
 #include "template.h"
 
+#include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
 


### PR DESCRIPTION
The compiler will give an error on the file `include/jinja2cpp/template_env.h` concerning the `std::unique_lock` is not included from the standard c++ template library until the patch is included.

The patch is briefly short:

```c++
diff --git a/include/jinja2cpp/template_env.h b/include/jinja2cpp/template_env.h
index d49859e..0bd456e 100644
--- a/include/jinja2cpp/template_env.h
+++ b/include/jinja2cpp/template_env.h
@@ -6,6 +6,7 @@
 #include "filesystem_handler.h"
 #include "template.h"
 
+#include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
```

It adresses and patches the compiler error shown below:

```cmake
[  4%] Building CXX object CMakeFiles/jinja2cpp.dir/src/error_info.cpp.o
[  6%] Building CXX object CMakeFiles/jinja2cpp.dir/src/expression_evaluator.cpp.o
[  9%] Building CXX object CMakeFiles/jinja2cpp.dir/src/expression_parser.cpp.o
In file included from /home/sebastian/.build/aurbuild/jinja2cpp/jinja2cpp/src/Jinja2Cpp/src/expression_parser.h:10,
                 from /home/sebastian/.build/aurbuild/jinja2cpp/jinja2cpp/src/Jinja2Cpp/src/expression_parser.cpp:1:
/home/sebastian/.build/aurbuild/jinja2cpp/jinja2cpp/src/Jinja2Cpp/include/jinja2cpp/template_env.h: In member function ‘void jinja2::TemplateEnv::AddGlobal(std::string, jinja2::Value)’:
/home/sebastian/.build/aurbuild/jinja2cpp/jinja2cpp/src/Jinja2Cpp/include/jinja2cpp/template_env.h:174:14: error: ‘unique_lock’ is not a member of ‘std’
  174 |         std::unique_lock<std::shared_timed_mutex> l(m_guard);
      |              ^~~~~~~~~~~
In file included from /home/sebastian/.build/aurbuild/jinja2cpp/jinja2cpp/src/Jinja2Cpp/src/expression_parser.h:10,
                 from /home/sebastian/.build/aurbuild/jinja2cpp/jinja2cpp/src/Jinja2Cpp/src/expression_parser.cpp:1:
/home/sebastian/.build/aurbuild/jinja2cpp/jinja2cpp/src/Jinja2Cpp/include/jinja2cpp/template_env.h:10:1: note: ‘std::unique_lock’ is defined in header ‘<mutex>’; did you forget to ‘#include <mutex>’?
    9 | #include <shared_mutex>
  +++ |+#include <mutex>
   10 | #include <unordered_map>
In file included from /home/sebastian/.build/aurbuild/jinja2cpp/jinja2cpp/src/Jinja2Cpp/src/expression_parser.h:10,
                 from /home/sebastian/.build/aurbuild/jinja2cpp/jinja2cpp/src/Jinja2Cpp/src/expression_parser.cpp:1:
/home/sebastian/.build/aurbuild/jinja2cpp/jinja2cpp/src/Jinja2Cpp/include/jinja2cpp/template_env.h:174:49: error: expected primary-expression before ‘>’ token
  174 |         std::unique_lock<std::shared_timed_mutex> l(m_guard);
      |                                                 ^
/home/sebastian/.build/aurbuild/jinja2cpp/jinja2cpp/src/Jinja2Cpp/include/jinja2cpp/template_env.h:174:51: error: ‘l’ was not declared in this scope
  174 |         std::unique_lock<std::shared_timed_mutex> l(m_guard);
      |                                                   ^
/home/sebastian/.build/aurbuild/jinja2cpp/jinja2cpp/src/Jinja2Cpp/include/jinja2cpp/template_env.h: In member function ‘void jinja2::TemplateEnv::RemoveGlobal(const string&)’:
/home/sebastian/.build/aurbuild/jinja2cpp/jinja2cpp/src/Jinja2Cpp/include/jinja2cpp/template_env.h:187:14: error: ‘unique_lock’ is not a member of ‘std’
  187 |         std::unique_lock<std::shared_timed_mutex> l(m_guard);
      |              ^~~~~~~~~~~
/home/sebastian/.build/aurbuild/jinja2cpp/jinja2cpp/src/Jinja2Cpp/include/jinja2cpp/template_env.h:187:14: note: ‘std::unique_lock’ is defined in header ‘<mutex>’; did you forget to ‘#include <mutex>’?
/home/sebastian/.build/aurbuild/jinja2cpp/jinja2cpp/src/Jinja2Cpp/include/jinja2cpp/template_env.h:187:49: error: expected primary-expression before ‘>’ token
  187 |         std::unique_lock<std::shared_timed_mutex> l(m_guard);
      |                                                 ^
/home/sebastian/.build/aurbuild/jinja2cpp/jinja2cpp/src/Jinja2Cpp/include/jinja2cpp/template_env.h:187:51: error: ‘l’ was not declared in this scope
  187 |         std::unique_lock<std::shared_timed_mutex> l(m_guard);
      |                                                   ^
make[2]: *** [CMakeFiles/jinja2cpp.dir/build.make:104: CMakeFiles/jinja2cpp.dir/src/expression_parser.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:304: CMakeFiles/jinja2cpp.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
==> ERROR: A failure occurred in build().
    Aborting...
makepkg -si  39.34s user 1.65s system 103% cpu 39.785 total
```