### PR TITLE
Mimic the behavior of the 'in' operator when applied to strings

### DIFF
--- a/test/testers_test.cpp
+++ b/test/testers_test.cpp
@@ -242,12 +242,14 @@ INSTANTIATE_TEST_SUITE_P(StringTest, TestersGenericTest, ::testing::Values(
 
 
 INSTANTIATE_TEST_SUITE_P(InTest, TestersGenericTest, ::testing::Values(
-                            InputOutputPair{"0 in (2, 1, 0)",           "true"},
-                            InputOutputPair{"0 in (1, 2, 3)",           "false"},
-                            InputOutputPair{"0 in intList",             "true"},
-                            InputOutputPair{"1000 in intList",          "false"},
-                            InputOutputPair{"'string9' in stringList",  "true"},
-                            InputOutputPair{"'string90' in stringList", "false"}
+                            InputOutputPair{"0 in (2, 1, 0)",             "true"},
+                            InputOutputPair{"0 in (1, 2, 3)",             "false"},
+                            InputOutputPair{"0 in intList",               "true"},
+                            InputOutputPair{"1000 in intList",            "false"},
+                            InputOutputPair{"'string9' in stringList",    "true"},
+                            InputOutputPair{"'string90' in stringList",   "false"},
+                            InputOutputPair{"'string' in 'a big string'", "true"},
+                            InputOutputPair{"'a big string' in 'substr'",  "false"}
                             ));
 
 INSTANTIATE_TEST_SUITE_P(EvenTest, TestersGenericTest, ::testing::Values(


### PR DESCRIPTION
In the original Jinja, when the 'in' operator is applied to strings it searches for a substring.
It happens naturally, as a string is a list of chars in Python. This logic wasn't translated to Jinja2cpp right away.
Examples:
AS IS:
```
'b' in 'abc' -> false
'abc' in 'b' -> false
```
EXPECTED:
```
'b' in 'abc' -> true
'abc' in 'b' -> false
```

This PR proposes a fix: expect two possible types of inputs - strings and lists. 
Lists are being treated the same way as before, for strings `sequence::find(substring)` is applied.