### PR TITLE
Rmorozov/fix std20

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -96,7 +96,7 @@ jobs:
       fail-fast: false
       max-parallel: 8
       matrix:
-        compiler: [10, 11]
+        compiler: [10, 11, 12]
         base-flags: ["", -DJINJA2CPP_CXX_STANDARD=17]
         build-config: [Release, Debug]
         build-shared: [TRUE, FALSE]
@@ -106,6 +106,8 @@ jobs:
             docker-image: conanio/clang10
           - compiler: 11
             docker-image: conanio/clang11
+          - compiler: 12
+            docker-image: conanio/clang12-ubuntu16.04
 
     steps:
     - uses: actions/checkout@v1
@@ -125,6 +127,8 @@ jobs:
         export BUILD_CONFIG=${INPUT_BASE_CONFIG}
         export WORKSPACE=$GITHUB_WORKSPACE
         $CXX --version
+        if [[ "${INPUT_COMPILER}" != "" ]]; then export CXX=${INPUT_COMPILER}; fi
+        if [[ "${INPUT_COMPILER}" == "clang-12" ]]; then export INPUT_BASE_FLAGS="-DJINJA2CPP_CXX_STANDARD=20"; fi
         export EXTRA_FLAGS="${INPUT_BASE_FLAGS} ${INPUT_EXTRA_FLAGS}"
         mkdir $BUILD_DIRECTORY && cd $BUILD_DIRECTORY
         sudo chmod gou+rw -R $WORKSPACE

--- a/src/error_info.cpp
+++ b/src/error_info.cpp
@@ -18,7 +18,12 @@ struct ValueRenderer
     {
     }
 
-    void operator()(bool val) const { fmt::format_to(ctx->out(), (val ? UNIVERSAL_STR("True") : UNIVERSAL_STR("False")).GetValue<CharT>()); }
+    constexpr void operator()(bool val) const {
+        fmt::format_to(
+                ctx->out(),
+                UNIVERSAL_STR("{}").GetValue<CharT>(),
+                (val ? UNIVERSAL_STR("True").GetValue<CharT>(): UNIVERSAL_STR("False").GetValue<CharT>()));
+    }
     void operator()(const jinja2::EmptyValue&) const { fmt::format_to(ctx->out(), UNIVERSAL_STR("").GetValue<CharT>()); }
     template<typename CharU>
     void operator()(const std::basic_string<CharU>& val) const

--- a/src/error_info.cpp
+++ b/src/error_info.cpp
@@ -83,7 +83,7 @@ struct ValueRenderer
         fmt::format_to(ctx->out(), UNIVERSAL_STR("{}").GetValue<CharT>(), val);
     }
 };
-}
+} // namespace
 
 namespace fmt
 {
@@ -103,7 +103,7 @@ struct formatter<jinja2::Value, CharT>
         return fmt::format_to(ctx.out(), UNIVERSAL_STR("").GetValue<CharT>());
     }
 };
-}
+} // namespace fmt
 
 namespace jinja2
 {
@@ -281,4 +281,4 @@ std::wostream& operator << (std::wostream& os, const ErrorInfoW& res)
     os << res.ToString();
     return os;
 }
-} // jinja2
+} // namespace jinja2

--- a/src/expression_evaluator.cpp
+++ b/src/expression_evaluator.cpp
@@ -596,5 +596,5 @@ CallParams EvaluateCallParams(const CallParamsInfo& info, RenderContext& context
     return result;
 }
 
-}
-}
+} // namespace helpers
+} // namespace jinja2

--- a/src/expression_parser.cpp
+++ b/src/expression_parser.cpp
@@ -603,4 +603,4 @@ ExpressionParser::ParseResult<ExpressionEvaluatorPtr<IfExpression>> ExpressionPa
     return result;
 }
 
-} // jinja2
+} // namespace jinja2

--- a/src/filesystem_handler.cpp
+++ b/src/filesystem_handler.cpp
@@ -144,4 +144,4 @@ CharFileStreamPtr RealFileSystem::OpenByteStream(const std::string& name) const
     return CharFileStreamPtr(nullptr, [](std::istream*){});
 }
 
-} // jinja2
+} // namespace jinja2

--- a/src/filters.cpp
+++ b/src/filters.cpp
@@ -1082,5 +1082,5 @@ InternalValue UserDefinedFilter::Filter(const InternalValue& baseVal, RenderCont
     return callable->GetExpressionCallable()(callParams, context);
 }
 
-} // filters
-} // jinja2
+} // namespace filters
+} // namespace jinja2

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -5,6 +5,7 @@
 #include <jinja2cpp/string_helpers.h>
 
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <cwchar>
 
@@ -15,10 +16,25 @@ struct MultiStringLiteral
     const char* charValue;
     const wchar_t* wcharValue;
 
-    template<typename CharT>
-    auto GetValue() const
+    constexpr MultiStringLiteral(const char* val, const wchar_t* wval)
+        : charValue(val)
+        , wcharValue(wval)
     {
-        auto memPtr = SelectMemberPtr<CharT, &MultiStringLiteral::charValue, &MultiStringLiteral::wcharValue>::GetPtr();
+    }
+
+    constexpr ~MultiStringLiteral() = default;
+
+    template<typename CharT>
+    constexpr auto GetValue() const
+    {
+        constexpr auto memPtr = SelectMemberPtr<CharT, &MultiStringLiteral::charValue, &MultiStringLiteral::wcharValue>::GetPtr();
+        return std::basic_string_view<CharT>(this->*memPtr);
+    }
+
+    template<typename CharT>
+    constexpr auto GetValueStr() const
+    {
+        constexpr auto memPtr = SelectMemberPtr<CharT, &MultiStringLiteral::charValue, &MultiStringLiteral::wcharValue>::GetPtr();
         return std::basic_string<CharT>(this->*memPtr);
     }
 
@@ -28,13 +44,13 @@ struct MultiStringLiteral
     template<const char* (MultiStringLiteral::*charMemPtr), const wchar_t* (MultiStringLiteral::*wcharMemPtr)>
     struct SelectMemberPtr<char, charMemPtr, wcharMemPtr>
     {
-        static auto GetPtr() {return charMemPtr;}
+        static constexpr auto GetPtr() {return charMemPtr;}
     };
 
     template<const char* (MultiStringLiteral::*charMemPtr), const wchar_t* (MultiStringLiteral::*wcharMemPtr)>
     struct SelectMemberPtr<wchar_t, charMemPtr, wcharMemPtr>
     {
-        static auto GetPtr() {return wcharMemPtr;}
+        static constexpr auto GetPtr() {return wcharMemPtr;}
     };
 
     template<typename CharT>

--- a/src/internal_value.cpp
+++ b/src/internal_value.cpp
@@ -859,6 +859,6 @@ InputValueConvertor::result_t InputValueConvertor::ConvertUserCallable(const Use
     }));
 }
 
-} // visitors
+} // namespace visitors
 
-} // jinja2
+} // namespace jinja2

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -119,4 +119,4 @@ bool Lexer::ProcessString(const lexertk::token&, Token& newToken)
     return true;
 }
 
-} // jinja2
+} // namespace jinja2

--- a/src/serialize_filters.cpp
+++ b/src/serialize_filters.cpp
@@ -241,7 +241,7 @@ struct FormatArgumentConverter : visitors::BaseVisitor<FormatArgument>
     bool m_named = false;
 };
 
-}
+} // namespace
 
 InternalValue StringFormat::Filter(const InternalValue& baseVal, RenderContext& context)
 {
@@ -437,5 +437,5 @@ InternalValue XmlAttrFilter::Filter(const InternalValue& baseVal, RenderContext&
     return Apply<XmlAttrPrinter>(baseVal, &context, true);
 }
 
-}
-}
+} // namespace filters
+} // namespace jinja2

--- a/src/statements.cpp
+++ b/src/statements.cpp
@@ -798,4 +798,4 @@ void FilterStatement::Render(OutStream& os, RenderContext& values)
     const auto result = m_expr->Evaluate(std::move(arg), values);
     os.WriteValue(result);
 }
-} // jinja2
+} // namespace jinja2

--- a/src/string_converter_filter.cpp
+++ b/src/string_converter_filter.cpp
@@ -352,17 +352,17 @@ InternalValue StringConverter::Filter(const InternalValue& baseVal, RenderContex
             auto str = sv_to_string(srcStr);
             using StringT = decltype(str);
             using CharT = typename StringT::value_type;
-            static const std::basic_regex<CharT> STRIPTAGS_RE(UNIVERSAL_STR("(<!--.*?-->|<[^>]*>)").GetValue<CharT>());
-            str = std::regex_replace(str, STRIPTAGS_RE, UNIVERSAL_STR("").GetValue<CharT>());
+            static const std::basic_regex<CharT> STRIPTAGS_RE(UNIVERSAL_STR("(<!--.*?-->|<[^>]*>)").GetValueStr<CharT>());
+            str = std::regex_replace(str, STRIPTAGS_RE, UNIVERSAL_STR("").GetValueStr<CharT>());
             ba::trim_all(str);
             static const StringT html_entities [] {
-                UNIVERSAL_STR("&amp;").GetValue<CharT>(), UNIVERSAL_STR("&").GetValue<CharT>(),
-                UNIVERSAL_STR("&apos;").GetValue<CharT>(), UNIVERSAL_STR("\'").GetValue<CharT>(),
-                UNIVERSAL_STR("&gt;").GetValue<CharT>(), UNIVERSAL_STR(">").GetValue<CharT>(),
-                UNIVERSAL_STR("&lt;").GetValue<CharT>(), UNIVERSAL_STR("<").GetValue<CharT>(),
-                UNIVERSAL_STR("&quot;").GetValue<CharT>(), UNIVERSAL_STR("\"").GetValue<CharT>(),
-                UNIVERSAL_STR("&#39;").GetValue<CharT>(), UNIVERSAL_STR("\'").GetValue<CharT>(),
-                UNIVERSAL_STR("&#34;").GetValue<CharT>(), UNIVERSAL_STR("\"").GetValue<CharT>(),
+                UNIVERSAL_STR("&amp;").GetValueStr<CharT>(), UNIVERSAL_STR("&").GetValueStr<CharT>(),
+                UNIVERSAL_STR("&apos;").GetValueStr<CharT>(), UNIVERSAL_STR("\'").GetValueStr<CharT>(),
+                UNIVERSAL_STR("&gt;").GetValueStr<CharT>(), UNIVERSAL_STR(">").GetValueStr<CharT>(),
+                UNIVERSAL_STR("&lt;").GetValueStr<CharT>(), UNIVERSAL_STR("<").GetValueStr<CharT>(),
+                UNIVERSAL_STR("&quot;").GetValueStr<CharT>(), UNIVERSAL_STR("\"").GetValueStr<CharT>(),
+                UNIVERSAL_STR("&#39;").GetValueStr<CharT>(), UNIVERSAL_STR("\'").GetValueStr<CharT>(),
+                UNIVERSAL_STR("&#34;").GetValueStr<CharT>(), UNIVERSAL_STR("\"").GetValueStr<CharT>(),
             };
             for (auto it = std::begin(html_entities), end = std::end(html_entities); it < end; it += 2)
             {

--- a/src/string_converter_filter.cpp
+++ b/src/string_converter_filter.cpp
@@ -391,5 +391,5 @@ InternalValue StringConverter::Filter(const InternalValue& baseVal, RenderContex
     return std::move(result);
 }
 
-}
-}
+} // namespace filters
+} // namespace jinja2

--- a/src/template.cpp
+++ b/src/template.cpp
@@ -168,4 +168,4 @@ ResultW<MetadataInfo<wchar_t>> TemplateW::GetMetadataRaw()
     // GetImpl<wchar_t>(m_impl)->GetMetadataRaw();
     ;
 }
-} // jinga2
+} // namespace jinja2

--- a/src/template_env.cpp
+++ b/src/template_env.cpp
@@ -92,4 +92,4 @@ nonstd::expected<TemplateW, ErrorInfoW> TemplateEnv::LoadTemplateW(std::string f
     return LoadTemplateImpl<wchar_t>(this, std::move(fileName), m_filesystemHandlers, m_templateWCache);
 }
 
-} // jinja2
+} // namespace jinja2

--- a/src/template_parser.cpp
+++ b/src/template_parser.cpp
@@ -968,4 +968,4 @@ StatementsParser::ParseResult StatementsParser::ParseEndFilter(LexScanner&, Stat
     return {};
 }
 
-}
+} // namespace jinja2

--- a/src/template_parser.h
+++ b/src/template_parser.h
@@ -59,7 +59,7 @@ template<>
 struct ParserTraits<char> : public ParserTraitsBase<>
 {
     static std::regex GetRoughTokenizer()
-    { return std::regex(s_regexp.GetValue<char>()); }
+    { return std::regex(s_regexp.GetValueStr<char>()); }
     static std::regex GetKeywords()
     {
         std::string pattern;
@@ -110,7 +110,7 @@ template<>
 struct ParserTraits<wchar_t> : public ParserTraitsBase<>
 {
     static std::wregex GetRoughTokenizer()
-    { return std::wregex(s_regexp.GetValue<wchar_t>()); }
+    { return std::wregex(s_regexp.GetValueStr<wchar_t>()); }
     static std::wregex GetKeywords()
     {
         std::wstring pattern;
@@ -748,10 +748,10 @@ private:
     {
         auto p = traits_t::s_tokens.find(tok.type);
         if (p != traits_t::s_tokens.end())
-            return p->second.template GetValue<CharT>();
+            return p->second.template GetValueStr<CharT>();
 
         if (tok.range.size() != 0)
-            return m_template->substr(tok.range.startOffset, tok.range.size());
+            return string_t(m_template->substr(tok.range.startOffset, tok.range.size()));
         else if (tok.type == Token::Identifier)
         {
             if (!tok.value.IsEmpty())
@@ -760,10 +760,10 @@ private:
                 return GetAsSameString(tpl, tok.value).value_or(std::basic_string<CharT>());
             }
 
-            return UNIVERSAL_STR("<<Identifier>>").template GetValue<CharT>();
+            return UNIVERSAL_STR("<<Identifier>>").template GetValueStr<CharT>();
         }
         else if (tok.type == Token::String)
-            return UNIVERSAL_STR("<<String>>").template GetValue<CharT>();
+            return UNIVERSAL_STR("<<String>>").template GetValueStr<CharT>();
 
         return string_t();
     }

--- a/src/testers.cpp
+++ b/src/testers.cpp
@@ -375,5 +375,5 @@ bool UserDefinedTester::Test(const InternalValue& baseVal, RenderContext& contex
         
     return ConvertToBool(callable->GetExpressionCallable()(callParams, context));
 }
-}
-}
+} // namespace testers
+} // namespace jinja2

--- a/test/filters_test.cpp
+++ b/test/filters_test.cpp
@@ -708,7 +708,7 @@ struct TypeReflection<TestValues> : TypeReflected<TestValues>
     }
 };
 
-}
+} // namespace jinja2
 
 TEST_F(XmlAttr, SerializeMapWithStringViewsAndNoneSerializebleValues)
 {

--- a/test/rapid_json_serializer_test.cpp
+++ b/test/rapid_json_serializer_test.cpp
@@ -10,7 +10,7 @@ jinja2::InternalValue MakeInternalValue(T&& v)
 {
     return jinja2::InternalValue(std::forward<T>(v));
 }
-}
+} // namespace
 TEST(RapidJsonSerializerTest, SerializeTrivialTypes)
 {
     const jinja2::rapidjson_serializer::DocumentWrapper document;

--- a/test/tojson_filter_test.cpp
+++ b/test/tojson_filter_test.cpp
@@ -70,7 +70,7 @@ void PrintTo(const nlohmann::json& json, std::ostream* os)
 {
     *os << json.dump();
 }
-}
+} // namespace nlohmann
 
 TEST_F(ToJson, SerializeObject)
 {


### PR DESCRIPTION
    Make jinja2cpp compilable under clang 12 with -std=c++20
    the problem arose from the fact that libfmt switched to consteval check of format
    string(that is great, but makes us obliged to provide format_to with
    constexpr format_string or fmt::runtime overload)

    unfortunatelly I couldn't make it work with constexpr std::string
    so multistringliteral returns std::basic_string_view except for cases
    where it needs std::string

    fix https://github.com/jinja2cpp/Jinja2Cpp/issues/213