### PR TITLE
apply llvm-header-guard, llvm-namespaces

### DIFF
--- a/include/jinja2cpp/error_info.h
+++ b/include/jinja2cpp/error_info.h
@@ -180,6 +180,6 @@ using ErrorInfoW = ErrorInfoTpl<wchar_t>;
 
 JINJA2CPP_EXPORT std::ostream& operator<<(std::ostream& os, const ErrorInfo& res);
 JINJA2CPP_EXPORT std::wostream& operator<<(std::wostream& os, const ErrorInfoW& res);
-} // jinja2
+} // namespace jinja2
 
 #endif // JINJA2CPP_ERROR_INFO_H

--- a/include/jinja2cpp/filesystem_handler.h
+++ b/include/jinja2cpp/filesystem_handler.h
@@ -171,6 +171,6 @@ public:
 private:
     std::string m_rootFolder;
 };
-} // jinja2
+} // namespace jinja2
 
-#endif // FILESYSTEM_HANDLER_H
+#endif // JINJA2CPP_FILESYSTEM_HANDLER_H

--- a/include/jinja2cpp/generic_list.h
+++ b/include/jinja2cpp/generic_list.h
@@ -1,5 +1,5 @@
-#ifndef JINJA2_GENERIC_LIST_H
-#define JINJA2_GENERIC_LIST_H
+#ifndef JINJA2CPP_GENERIC_LIST_H
+#define JINJA2CPP_GENERIC_LIST_H
 
 #include <nonstd/optional.hpp>
 
@@ -157,7 +157,7 @@ struct ListItemAccessor
 namespace detail
 {
 class GenericListIterator;
-}
+} // namespace detail
 
 /*!
  * \brief Facade class for generic lists
@@ -265,7 +265,7 @@ inline ListEnumeratorPtr ListItemAccessor::MakeEnumerator(Args&& ...args)
 {
     return ListEnumeratorPtr(new T(std::forward<Args>(args)...), [](ListEnumerator* e) { delete e; });
 }
-}
+} // namespace jinja2
 
 
-#endif // JINJA2_GENERIC_LIST_H
+#endif // JINJA2CPP_GENERIC_LIST_H

--- a/include/jinja2cpp/generic_list_impl.h
+++ b/include/jinja2cpp/generic_list_impl.h
@@ -343,7 +343,7 @@ auto MakeGeneratedList(ListGenerator&& fn)
 {
     return GenericList([accessor = GeneratedListAccessor(std::move(fn))]() {return &accessor;});
 }
-}
+} // namespace lists_impl
 
 /*!
  * \brief Create instance of the GenericList from the pair of iterators
@@ -385,6 +385,6 @@ auto MakeGenericList(lists_impl::ListGenerator fn)
     return lists_impl::MakeGeneratedList(std::move(fn));
 }
 
-}
+} // namespace jinja2
 
-#endif //JINJA2CPP_GENERIC_LIST_IMPL_H
+#endif // JINJA2CPP_GENERIC_LIST_IMPL_H

--- a/include/jinja2cpp/generic_list_iterator.h
+++ b/include/jinja2cpp/generic_list_iterator.h
@@ -1,5 +1,5 @@
-#ifndef JINJA2_GENERIC_LIST_ITERATOR_H
-#define JINJA2_GENERIC_LIST_ITERATOR_H
+#ifndef JINJA2CPP_GENERIC_LIST_ITERATOR_H
+#define JINJA2CPP_GENERIC_LIST_ITERATOR_H
 
 #include "generic_list.h"
 #include "value.h"
@@ -94,7 +94,7 @@ private:
     Value m_current;
 };
 
-}
+} // namespace detail
 
 inline detail::GenericListIterator GenericList::begin() const
 {
@@ -108,6 +108,6 @@ inline detail::GenericListIterator GenericList::end() const
 
 inline auto GenericList::cbegin() const {return begin();}
 inline auto GenericList::cend() const {return end();}
-}
+} // namespace jinja2
 
-#endif // JINJA2_GENERIC_LIST_ITERATOR_H
+#endif // JINJA2CPP_GENERIC_LIST_ITERATOR_H

--- a/include/jinja2cpp/reflected_value.h
+++ b/include/jinja2cpp/reflected_value.h
@@ -1,5 +1,5 @@
-#ifndef JINJA2_REFLECTED_VALUE_H
-#define JINJA2_REFLECTED_VALUE_H
+#ifndef JINJA2CPP_REFLECTED_VALUE_H
+#define JINJA2CPP_REFLECTED_VALUE_H
 
 #include "value.h"
 
@@ -522,7 +522,7 @@ JINJA2_INT_REFLECTOR(int32_t);
 JINJA2_INT_REFLECTOR(uint32_t);
 JINJA2_INT_REFLECTOR(int64_t);
 JINJA2_INT_REFLECTOR(uint64_t);
-} // detail
+} // namespace detail
 #endif
 
 template<typename T>
@@ -531,6 +531,6 @@ Value Reflect(T&& val)
     return detail::Reflector<T>::Create(std::forward<T>(val));
 }
 
-} // jinja2
+} // namespace jinja2
 
-#endif // JINJA2_REFLECTED_VALUE_H
+#endif // JINJA2CPP_REFLECTED_VALUE_H

--- a/include/jinja2cpp/string_helpers.h
+++ b/include/jinja2cpp/string_helpers.h
@@ -1,5 +1,5 @@
-#ifndef JINJA2_STRING_HELPERS_H
-#define JINJA2_STRING_HELPERS_H
+#ifndef JINJA2CPP_STRING_HELPERS_H
+#define JINJA2CPP_STRING_HELPERS_H
 
 #include <nonstd/string_view.hpp>
 #include "value.h"
@@ -98,7 +98,7 @@ namespace detail
     template<typename CharT, typename T>
     struct StringConverter<nonstd::basic_string_view<CharT>, T> : public StringConverter<std::basic_string<CharT>, T> {};
 
-} // detail
+} // namespace detail
 
 /*!
  * \brief Convert string objects from one representation or another
@@ -261,7 +261,7 @@ struct WStringGetter
         return std::wstring();
     }
 };
-}
+} // namespace detail
 /*!
  * \brief Gets std::string from the arbitrary \ref Value
  *
@@ -290,6 +290,6 @@ inline std::wstring AsWString(const Value& val)
 {
     return nonstd::visit(detail::WStringGetter(), val.data());
 }
-}
+} // namespace jinja2
 
-#endif // JINJA2_STRING_HELPERS_H
+#endif // JINJA2CPP_STRING_HELPERS_H

--- a/include/jinja2cpp/template.h
+++ b/include/jinja2cpp/template.h
@@ -1,5 +1,5 @@
-#ifndef JINJA2_TEMPLATE_H
-#define JINJA2_TEMPLATE_H
+#ifndef JINJA2CPP_TEMPLATE_H
+#define JINJA2CPP_TEMPLATE_H
 
 #include "config.h"
 #include "error_info.h"
@@ -279,6 +279,6 @@ private:
     std::shared_ptr<ITemplateImpl> m_impl;
     friend class TemplateImpl<wchar_t>;
 };
-} // jinja2
+} // namespace jinja2
 
-#endif // JINJA2_TEMPLATE_H
+#endif // JINJA2CPP_TEMPLATE_H

--- a/include/jinja2cpp/template_env.h
+++ b/include/jinja2cpp/template_env.h
@@ -242,6 +242,6 @@ private:
     std::unordered_map<std::string, TemplateWCacheEntry> m_templateWCache;
 };
 
-} // jinja2
+} // namespace jinja2
 
 #endif // JINJA2CPP_TEMPLATE_ENV_H

--- a/include/jinja2cpp/user_callable.h
+++ b/include/jinja2cpp/user_callable.h
@@ -1,5 +1,5 @@
-#ifndef USER_CALLABLE_H
-#define USER_CALLABLE_H
+#ifndef JINJA2CPP_USER_CALLABLE_H
+#define JINJA2CPP_USER_CALLABLE_H
 
 #include "string_helpers.h"
 #include "value.h"
@@ -340,7 +340,7 @@ template<typename... T>
 struct ArgDescrHasType<ArgInfoT<T>...> : std::true_type
 {
 };
-} // detail
+} // namespace detail
 #endif // JINJA2CPP_NO_DOXYGEN
 
 /*!
@@ -431,6 +431,6 @@ auto MakeCallable(Fn&& f)
 {
     return UserCallable{ [=, fn = std::forward<Fn>(f)](const UserCallableParams&) { return fn(); }, {} };
 }
-} // jinja2
+} // namespace jinja2
 
-#endif // USER_CALLABLE_H
+#endif // JINJA2CPP_USER_CALLABLE_H

--- a/include/jinja2cpp/value.h
+++ b/include/jinja2cpp/value.h
@@ -1,5 +1,5 @@
-#ifndef JINJA2_VALUE_H
-#define JINJA2_VALUE_H
+#ifndef JINJA2CPP_VALUE_H
+#define JINJA2CPP_VALUE_H
 
 #include "generic_list.h"
 #include "value_ptr.hpp"
@@ -652,6 +652,6 @@ inline Value::Value(ValuesMap&& map) noexcept
 {
 }
 
-} // jinja2
+} // namespace jinja2
 
-#endif // JINJA2_VALUE_H
+#endif // JINJA2CPP_VALUE_H

--- a/include/jinja2cpp/value_ptr.hpp
+++ b/include/jinja2cpp/value_ptr.hpp
@@ -1,3 +1,6 @@
+#ifndef JINJA2CPP_VALUE_PTR_HPP
+#define JINJA2CPP_VALUE_PTR_HPP
+
 //
 // Copyright 2017-2018 by Martin Moene
 //
@@ -1288,3 +1291,5 @@ struct hash< nonstd::value_ptr<T, D, C> >
 #endif
 
 #endif // NONSTD_VALUE_PTR_LITE_HPP
+
+#endif

--- a/src/ast_visitor.h
+++ b/src/ast_visitor.h
@@ -1,5 +1,5 @@
-#ifndef AST_VISITOR_H
-#define AST_VISITOR_H
+#ifndef JINJA2CPP_SRC_AST_VISITOR_H
+#define JINJA2CPP_SRC_AST_VISITOR_H
 
 namespace jinja2
 {
@@ -76,7 +76,7 @@ struct VisitorBase
 {
     using type = typename VisitorBaseImpl<void, Types ...>::base_type;
 };
-}
+} // namespace detail
 
 template<typename ... Types>
 using VisitorBase = typename detail::VisitorBase<Types...>::type;
@@ -109,7 +109,7 @@ public:
         stmt->ApplyVisitor(this);
     }
 };
-}
+} // namespace jinja2
 
 
 #endif

--- a/src/error_handling.h
+++ b/src/error_handling.h
@@ -1,5 +1,5 @@
-#ifndef ERROR_HANDLING_H
-#define ERROR_HANDLING_H
+#ifndef JINJA2CPP_SRC_ERROR_HANDLING_H
+#define JINJA2CPP_SRC_ERROR_HANDLING_H
 
 #include "lexer.h"
 #include <jinja2cpp/error_info.h>
@@ -59,5 +59,5 @@ inline auto MakeParseError(ErrorCode code, Token tok, std::initializer_list<Toke
     return nonstd::make_unexpected(ParseError{code, tok, toks});
 }
 
-} // jinja2
-#endif // ERROR_HANDLING_H
+} // namespace jinja2
+#endif // JINJA2CPP_SRC_ERROR_HANDLING_H

--- a/src/expression_evaluator.h
+++ b/src/expression_evaluator.h
@@ -1,5 +1,5 @@
-#ifndef EXPRESSION_EVALUATOR_H
-#define EXPRESSION_EVALUATOR_H
+#ifndef JINJA2CPP_SRC_EXPRESSION_EVALUATOR_H
+#define JINJA2CPP_SRC_EXPRESSION_EVALUATOR_H
 
 #include "internal_value.h"
 #include "render_context.h"
@@ -376,7 +376,7 @@ ParsedArguments ParseCallParams(const std::vector<ArgumentInfo>& args, const Cal
 ParsedArgumentsInfo ParseCallParamsInfo(const std::initializer_list<ArgumentInfo>& argsInfo, const CallParamsInfo& params, bool& isSucceeded);
 ParsedArgumentsInfo ParseCallParamsInfo(const std::vector<ArgumentInfo>& args, const CallParamsInfo& params, bool& isSucceeded);
 CallParams EvaluateCallParams(const CallParamsInfo& info, RenderContext& context);
-}
-} // jinja2
+} // namespace helpers
+} // namespace jinja2
 
-#endif // EXPRESSION_EVALUATOR_H
+#endif // JINJA2CPP_SRC_EXPRESSION_EVALUATOR_H

--- a/src/expression_parser.h
+++ b/src/expression_parser.h
@@ -1,5 +1,5 @@
-#ifndef EXPRESSION_PARSER_H
-#define EXPRESSION_PARSER_H
+#ifndef JINJA2CPP_SRC_EXPRESSION_PARSER_H
+#define JINJA2CPP_SRC_EXPRESSION_PARSER_H
 
 #include "lexer.h"
 #include "error_handling.h"
@@ -44,6 +44,6 @@ private:
     ComposedRenderer* m_topLevelRenderer = nullptr;
 };
 
-} // jinja2
+} // namespace jinja2
 
-#endif // EXPRESSION_PARSER_H
+#endif // JINJA2CPP_SRC_EXPRESSION_PARSER_H

--- a/src/filters.h
+++ b/src/filters.h
@@ -1,5 +1,5 @@
-#ifndef FILTERS_H
-#define FILTERS_H
+#ifndef JINJA2CPP_SRC_FILTERS_H
+#define JINJA2CPP_SRC_FILTERS_H
 
 #include "expression_evaluator.h"
 #include "function_base.h"
@@ -273,7 +273,7 @@ private:
     FilterParams m_callParams;
 };
 
-} // filters
-} // jinja2
+} // namespace filters
+} // namespace jinja2
 
-#endif // FILTERS_H
+#endif // JINJA2CPP_SRC_FILTERS_H

--- a/src/function_base.h
+++ b/src/function_base.h
@@ -1,5 +1,5 @@
-#ifndef FUNCTION_BASE_H
-#define FUNCTION_BASE_H
+#ifndef JINJA2CPP_SRC_FUNCTION_BASE_H
+#define JINJA2CPP_SRC_FUNCTION_BASE_H
 
 #include "expression_evaluator.h"
 #include "internal_value.h"
@@ -31,6 +31,6 @@ inline InternalValue FunctionBase::GetArgumentValue(const std::string& argName, 
     return argExpr ? argExpr->Evaluate(context) : std::move(defVal);
 }
 
-} // jinja2
+} // namespace jinja2
 
-#endif // FUNCTION_BASE_H
+#endif // JINJA2CPP_SRC_FUNCTION_BASE_H

--- a/src/generic_adapters.h
+++ b/src/generic_adapters.h
@@ -1,5 +1,5 @@
-#ifndef GENERIC_ADAPTERS_H
-#define GENERIC_ADAPTERS_H
+#ifndef JINJA2CPP_SRC_GENERIC_ADAPTERS_H
+#define JINJA2CPP_SRC_GENERIC_ADAPTERS_H
 
 #include <jinja2cpp/value.h>
 #include "internal_value.h"
@@ -183,6 +183,6 @@ inline ListEnumeratorPtr IndexedListItemAccessorImpl<T>::CreateEnumerator() cons
     return MakeEnumerator<Enumerator>(this);
 }
 
-} // jinja2
+} // namespace jinja2
 
-#endif // GENERIC_ADAPTERS_H
+#endif // JINJA2CPP_SRC_GENERIC_ADAPTERS_H

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -1,5 +1,5 @@
-#ifndef HELPERS_H
-#define HELPERS_H
+#ifndef JINJA2CPP_SRC_HELPERS_H
+#define JINJA2CPP_SRC_HELPERS_H
 
 #include <nonstd/string_view.hpp>
 #include <jinja2cpp/string_helpers.h>
@@ -114,6 +114,6 @@ Sequence CompileEscapes(Sequence s)
    return s;
 }
 
-} // jinja2
+} // namespace jinja2
 
-#endif // HELPERS_H
+#endif // JINJA2CPP_SRC_HELPERS_H

--- a/src/internal_value.h
+++ b/src/internal_value.h
@@ -1,5 +1,5 @@
-#ifndef INTERNAL_VALUE_H
-#define INTERNAL_VALUE_H
+#ifndef JINJA2CPP_SRC_INTERNAL_VALUE_H
+#define JINJA2CPP_SRC_INTERNAL_VALUE_H
 
 #include <jinja2cpp/value.h>
 
@@ -646,6 +646,6 @@ ListAdapter ConvertToList(const InternalValue& val, InternalValue subscipt, bool
 Value IntValue2Value(const InternalValue& val);
 Value OptIntValue2Value(nonstd::optional<InternalValue> val);
 
-} // jinja2
+} // namespace jinja2
 
-#endif // INTERNAL_VALUE_H
+#endif // JINJA2CPP_SRC_INTERNAL_VALUE_H

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -1,5 +1,5 @@
-#ifndef LEXER_H
-#define LEXER_H
+#ifndef JINJA2CPP_SRC_LEXER_H
+#define JINJA2CPP_SRC_LEXER_H
 
 #include "lexertk.h"
 #include "internal_value.h"
@@ -358,7 +358,7 @@ private:
     }
 };
 
-} // jinja2
+} // namespace jinja2
 
 namespace std
 {
@@ -370,6 +370,6 @@ struct hash<jinja2::Keyword>
         return std::hash<int>{}(static_cast<int>(kw));
     }
 };
-}
+} // namespace std
 
-#endif // LEXER_H
+#endif // JINJA2CPP_SRC_LEXER_H

--- a/src/lexertk.h
+++ b/src/lexertk.h
@@ -38,8 +38,8 @@
 */
 
 
-#ifndef INCLUDE_LEXERTK_HPP
-#define INCLUDE_LEXERTK_HPP
+#ifndef JINJA2CPP_SRC_LEXERTK_H
+#define JINJA2CPP_SRC_LEXERTK_H
 
 #include <algorithm>
 #include <cctype>
@@ -281,7 +281,7 @@ namespace lexertk
          }
       };
 
-   }
+   } // namespace details
 
    struct token
    {
@@ -1837,6 +1837,6 @@ namespace lexertk
       token_t     current_token_;
    };
 #endif
-}
+} // namespace lexertk
 
 #endif

--- a/src/out_stream.h
+++ b/src/out_stream.h
@@ -1,5 +1,5 @@
-#ifndef OUT_STREAM_H
-#define OUT_STREAM_H
+#ifndef JINJA2CPP_SRC_OUT_STREAM_H
+#define JINJA2CPP_SRC_OUT_STREAM_H
 
 #include "internal_value.h"
 #include <functional>
@@ -37,6 +37,6 @@ private:
     std::function<StreamWriter*()> m_writerGetter;
 };
 
-} // jinja2
+} // namespace jinja2
 
-#endif // OUT_STREAM_H
+#endif // JINJA2CPP_SRC_OUT_STREAM_H

--- a/src/rapid_json_serializer.h
+++ b/src/rapid_json_serializer.h
@@ -1,5 +1,5 @@
-#ifndef JINJA2CPP_RAPID_JSON_SERIALIZER_H
-#define JINJA2CPP_RAPID_JSON_SERIALIZER_H
+#ifndef JINJA2CPP_SRC_RAPID_JSON_SERIALIZER_H
+#define JINJA2CPP_SRC_RAPID_JSON_SERIALIZER_H
 
 #include "internal_value.h"
 
@@ -47,4 +47,4 @@ private:
 } // namespace rapidjson_serializer
 } // namespace jinja2
 
-#endif // JINJA2CPP_RAPID_JSON_SERIALIZER_H
+#endif // JINJA2CPP_SRC_RAPID_JSON_SERIALIZER_H

--- a/src/render_context.h
+++ b/src/render_context.h
@@ -1,5 +1,5 @@
-#ifndef RENDER_CONTEXT_H
-#define RENDER_CONTEXT_H
+#ifndef JINJA2CPP_SRC_RENDER_CONTEXT_H
+#define JINJA2CPP_SRC_RENDER_CONTEXT_H
 
 #include "internal_value.h"
 
@@ -135,6 +135,6 @@ private:
     IRendererCallback* m_rendererCallback;
     const InternalValueMap* m_boundScope = nullptr;
 };
-} // jinja2
+} // namespace jinja2
 
-#endif // RENDER_CONTEXT_H
+#endif // JINJA2CPP_SRC_RENDER_CONTEXT_H

--- a/src/renderer.h
+++ b/src/renderer.h
@@ -1,5 +1,5 @@
-#ifndef RENDERER_H
-#define RENDERER_H
+#ifndef JINJA2CPP_SRC_RENDERER_H
+#define JINJA2CPP_SRC_RENDERER_H
 
 #include "jinja2cpp/value.h"
 #include "out_stream.h"
@@ -84,6 +84,6 @@ public:
 private:
     ExpressionEvaluatorPtr<> m_expression;
 };
-} // jinja2
+} // namespace jinja2
 
-#endif // RENDERER_H
+#endif // JINJA2CPP_SRC_RENDERER_H

--- a/src/statements.h
+++ b/src/statements.h
@@ -1,5 +1,5 @@
-#ifndef STATEMENTS_H
-#define STATEMENTS_H
+#ifndef JINJA2CPP_SRC_STATEMENTS_H
+#define JINJA2CPP_SRC_STATEMENTS_H
 
 #include "renderer.h"
 #include "expression_evaluator.h"
@@ -431,7 +431,7 @@ private:
     ExpressionEvaluatorPtr<ExpressionFilter> m_expr;
     RendererPtr m_body;
 };
-} // jinja2
+} // namespace jinja2
 
 
-#endif // STATEMENTS_H
+#endif // JINJA2CPP_SRC_STATEMENTS_H

--- a/src/template_impl.h
+++ b/src/template_impl.h
@@ -1,5 +1,5 @@
-#ifndef TEMPLATE_IMPL_H
-#define TEMPLATE_IMPL_H
+#ifndef JINJA2CPP_SRC_TEMPLATE_IMPL_H
+#define JINJA2CPP_SRC_TEMPLATE_IMPL_H
 
 #include "internal_value.h"
 #include "jinja2cpp/binding/rapid_json.h"
@@ -54,7 +54,7 @@ struct RapidJsonEncodingType<4>
     using type = rapidjson::UTF32LE<wchar_t>;
 };
 #endif
-}
+} // namespace detail
 
 extern void SetupGlobals(InternalValueMap& globalParams);
 
@@ -397,6 +397,6 @@ private:
     MetadataInfo<CharT> m_metadataInfo;
 };
 
-} // jinja2
+} // namespace jinja2
 
-#endif // TEMPLATE_IMPL_H
+#endif // JINJA2CPP_SRC_TEMPLATE_IMPL_H

--- a/src/template_parser.h
+++ b/src/template_parser.h
@@ -1,5 +1,5 @@
-#ifndef TEMPLATE_PARSER_H
-#define TEMPLATE_PARSER_H
+#ifndef JINJA2CPP_SRC_TEMPLATE_PARSER_H
+#define JINJA2CPP_SRC_TEMPLATE_PARSER_H
 
 #include "error_handling.h"
 #include "expression_parser.h"
@@ -1059,6 +1059,6 @@ std::unordered_map<int, MultiStringLiteral> ParserTraitsBase<T>::s_tokens = {
     { Token::ExprEnd, UNIVERSAL_STR("}}") },
 };
 
-} // jinga2
+} // namespace jinja2
 
-#endif // TEMPLATE_PARSER_H
+#endif // JINJA2CPP_SRC_TEMPLATE_PARSER_H

--- a/src/testers.h
+++ b/src/testers.h
@@ -1,5 +1,5 @@
-#ifndef TESTERS_H
-#define TESTERS_H
+#ifndef JINJA2CPP_SRC_TESTERS_H
+#define JINJA2CPP_SRC_TESTERS_H
 
 #include "expression_evaluator.h"
 #include "function_base.h"
@@ -81,7 +81,7 @@ private:
     std::string m_testerName;
     TesterParams m_callParams;
 };
-} // testers
-} // jinja2
+} // namespace testers
+} // namespace jinja2
 
-#endif // TESTERS_H
+#endif // JINJA2CPP_SRC_TESTERS_H

--- a/src/value_helpers.h
+++ b/src/value_helpers.h
@@ -1,5 +1,5 @@
-#ifndef VALUE_HELPERS_H
-#define VALUE_HELPERS_H
+#ifndef JINJA2CPP_SRC_VALUE_HELPERS_H
+#define JINJA2CPP_SRC_VALUE_HELPERS_H
 
 #include <jinja2cpp/value.h>
 
@@ -162,6 +162,6 @@ inline auto end(const GenericList& list)
     return ConstGenericListIterator();
 }
 #endif
-} // jinja2
+} // namespace jinja2
 
-#endif // VALUE_HELPERS_H
+#endif // JINJA2CPP_SRC_VALUE_HELPERS_H

--- a/src/value_visitors.h
+++ b/src/value_visitors.h
@@ -1,5 +1,5 @@
-#ifndef VALUE_VISITORS_H
-#define VALUE_VISITORS_H
+#ifndef JINJA2CPP_SRC_VALUE_VISITORS_H
+#define JINJA2CPP_SRC_VALUE_VISITORS_H
 
 #include "expression_evaluator.h"
 #include "helpers.h"
@@ -77,7 +77,7 @@ auto ApplyUnwrapped(const InternalValueData& val, Fn&& fn)
 
     return fn(val);
 }
-} // detail
+} // namespace detail
 
 template<typename V, typename ... Args>
 auto Apply(const InternalValue& val, Args&& ... args)
@@ -1089,7 +1089,7 @@ struct SameStringGetter : public visitors::BaseVisitor<nonstd::expected<void, st
     }
 };
 
-} // visitors
+} // namespace visitors
 
 inline bool ConvertToBool(const InternalValue& val)
 {
@@ -1134,6 +1134,6 @@ auto GetAsSameString(const nonstd::basic_string_view<CharT>&, const InternalValu
     return Result();
 }
 
-} // jinja2
+} // namespace jinja2
 
-#endif // VALUE_VISITORS_H
+#endif // JINJA2CPP_SRC_VALUE_VISITORS_H

--- a/test/test_tools.h
+++ b/test/test_tools.h
@@ -1,5 +1,5 @@
-#ifndef TEST_TOOLS_H
-#define TEST_TOOLS_H
+#ifndef JINJA2CPP_TEST_TEST_TOOLS_H
+#define JINJA2CPP_TEST_TEST_TOOLS_H
 
 #include "../src/helpers.h"
 
@@ -373,6 +373,6 @@ struct TypeReflection<TestStruct> : TypeReflected<TestStruct>
         return accessors;
     }
 };
-} // jinja2
+} // namespace jinja2
 
-#endif // TEST_TOOLS_H
+#endif // JINJA2CPP_TEST_TEST_TOOLS_H


### PR DESCRIPTION
run clang-tidy checks llvm-header-guard, llvm-namespaces to update code style