### PR TITLE
Fix empty dict literal parsing

### DIFF
--- a/src/expression_parser.cpp
+++ b/src/expression_parser.cpp
@@ -370,7 +370,7 @@ ExpressionParser::ParseResult<ExpressionEvaluatorPtr<Expression>> ExpressionPars
     ExpressionEvaluatorPtr<Expression> result;
 
     std::unordered_map<std::string, ExpressionEvaluatorPtr<Expression>> items;
-    if (lexer.EatIfEqual(']'))
+    if (lexer.EatIfEqual('}'))
         return std::make_shared<DictCreator>(std::move(items));
 
     do

--- a/test/expressions_test.cpp
+++ b/test/expressions_test.cpp
@@ -100,6 +100,19 @@ rain
     };
 }
 
+MULTISTR_TEST(ExpressionsMultiStrTest, EmptyDict,
+R"(
+{% set d = {} %}
+{{ d.asdf|default(42) }}
+)",
+//-----------
+R"(
+
+42
+)")
+{
+}
+
 TEST(ExpressionTest, DoStatement)
 {
     std::string source = R"(


### PR DESCRIPTION
Jinja2Cpp parses {] as an empty dictionary and fails to parse {}.
I expected the opposite behaviour.