### PR TITLE
Add collections builtin methods

### DIFF
--- a/src/internal_value.cpp
+++ b/src/internal_value.cpp
@@ -278,6 +278,11 @@ struct ListConverter : public visitors::BaseVisitor<boost::optional<ListAdapter>
         return ListAdapter::CreateAdapter(std::move(list));
     }
 
+    result_t operator()(const KeyValuePair& kv) const
+    {
+        return ListAdapter::CreateAdapter(InternalValueList{kv.key, kv.value});
+    }
+
     template<typename CharT>
     result_t operator() (const std::basic_string<CharT>& str) const
     {

--- a/src/internal_value.h
+++ b/src/internal_value.h
@@ -220,6 +220,7 @@ struct IListAccessor
     virtual ListAccessorEnumeratorPtr CreateListAccessorEnumerator() const = 0;
     virtual GenericList CreateGenericList() const = 0;
     virtual bool ShouldExtendLifetime() const = 0;
+    virtual bool Append(const InternalValue& value) const { return false; }
 };
 
 
@@ -288,6 +289,15 @@ public:
         return GenericList();
     }
     ListAccessorEnumeratorPtr GetEnumerator() const;
+
+    bool Append(const InternalValue& value) const
+    {
+        if (m_accessorProvider && m_accessorProvider())
+            return m_accessorProvider()->Append(value);
+        return false;
+    }
+
+    InternalValue GetBuiltinMethod(const std::string& name) const;
 
     class Iterator;
 

--- a/src/internal_value.h
+++ b/src/internal_value.h
@@ -370,6 +370,8 @@ public:
         return GenericMap();
     }
 
+    InternalValue GetBuiltinMethod(const std::string& name) const;
+
 private:
     MapAccessorProvider m_accessorProvider;
 };

--- a/test/expressions_test.cpp
+++ b/test/expressions_test.cpp
@@ -113,6 +113,25 @@ R"(
 {
 }
 
+MULTISTR_TEST(ExpressionsMultiStrTest, ListAppendAndExtend,
+R"(
+{% set l = ['1'] %}
+{{ l|join(',') }}
+{{ l.append('2') }}
+{{ l.extend(['3','4']) }}
+{{ l|join(',') }}
+)",
+//-----------
+R"(
+
+1
+
+
+1,2,3,4
+)")
+{
+}
+
 TEST(ExpressionTest, DoStatement)
 {
     std::string source = R"(

--- a/test/expressions_test.cpp
+++ b/test/expressions_test.cpp
@@ -132,6 +132,41 @@ R"(
 {
 }
 
+MULTISTR_TEST(ExpressionsMultiStrTest, DictUpdate,
+R"(
+{% set a = {'a'='1'} %}
+{{ a['a'] }}
+{{ a['b'] }}
+{{ a['c'] }}
+{{ a['d'] }}
+{{ a['e'] }}
+{{ a.update({'b'='2','c'=3}) }}
+{{ a.update(d=4,e=5) }}
+{{ a['a'] }}
+{{ a['b'] }}
+{{ a['c'] }}
+{{ a['d'] }}
+{{ a['e'] }}
+)",
+//-----------
+R"(
+
+1
+
+
+
+
+
+
+1
+2
+3
+4
+5
+)")
+{
+}
+
 TEST(ExpressionTest, DoStatement)
 {
     std::string source = R"(

--- a/test/statements_tets.cpp
+++ b/test/statements_tets.cpp
@@ -452,3 +452,23 @@ TEST(RawTest, CommentRaw)
     std::cout << result << std::endl;
     EXPECT_STREQ("", result.c_str());
 }
+
+using ForTest = BasicTemplateRenderer;
+
+MULTISTR_TEST(ForTest, ForKeyValueInDictSorted,
+R"(
+{% set d = {'a'=1,'b'=2} %}
+{% for k, v in d|dictsort %}
+{{ k }}: {{ v }}
+{%- endfor %}
+)",
+//------------
+R"(
+
+
+a: 1
+b: 2
+)"
+)
+{
+}

--- a/test/statements_tets.cpp
+++ b/test/statements_tets.cpp
@@ -472,3 +472,21 @@ b: 2
 )
 {
 }
+
+MULTISTR_TEST(ForTest, ForKeyValueInDictItems,
+R"(
+{% set d = {'a'=1,'b'=2} %}
+{% for k, v in d.items() %}
+{{ k }}: {{ v }}
+{%- endfor %}
+)",
+//------------
+R"(
+
+
+a: 1
+b: 2
+)"
+)
+{
+}


### PR DESCRIPTION
- list.append
- list.extend
- dict.update
- dict.items

I've also fixed for loop: it doesn't handle lists of key-value pairs, that's why `for k, v in d|dictsort` doesn't work.