### PR TITLE
Update boost dependencies

### DIFF
--- a/thirdparty/external_boost_deps.cmake
+++ b/thirdparty/external_boost_deps.cmake
@@ -33,13 +33,13 @@ if (boost_algorithm_FOUND AND
    boost_json_FOUND AND
    boost_optional_FOUND AND
    boost_variant_FOUND AND boost_regex_FOUND)
-   imported_target_alias(boost_algorithm          ALIAS boost_algorithm::boost_algorithm)
-   imported_target_alias(boost_filesystem         ALIAS boost_filesystem::boost_filesystem)
-   imported_target_alias(boost_numeric_conversion ALIAS numeric_conversion::numeric_conversion)
-   imported_target_alias(boost_json               ALIAS boost_json::boost_json)
-   imported_target_alias(boost_optional           ALIAS boost_optional::boost_optional)
-   imported_target_alias(boost_variant            ALIAS boost_variant::boost_variant)
-   imported_target_alias(boost_regex              ALIAS boost_regex::boost_regex)
+   imported_target_alias(boost_algorithm          ALIAS boost_algorithm)
+   imported_target_alias(boost_filesystem         ALIAS boost_filesystem)
+   imported_target_alias(boost_numeric_conversion ALIAS numeric_conversion)
+   imported_target_alias(boost_json               ALIAS boost_json)
+   imported_target_alias(boost_optional           ALIAS boost_optional)
+   imported_target_alias(boost_variant            ALIAS boost_variant)
+   imported_target_alias(boost_regex              ALIAS boost_regex)
 else ()
     find_package(Boost COMPONENTS system filesystem numeric_conversion json regex ${FIND_BOOST_PACKAGE_QUIET} REQUIRED)
 

--- a/thirdparty/external_boost_deps.cmake
+++ b/thirdparty/external_boost_deps.cmake
@@ -54,7 +54,7 @@ else ()
         imported_target_alias(boost_optional           ALIAS Boost::boost)
         imported_target_alias(boost_variant            ALIAS Boost::boost)
         imported_target_alias(boost_regex              ALIAS Boost::regex)
-        imported_target_alias(boost_lexical_cast       ALIAS boost_regex::lexical_cast)
+        imported_target_alias(boost_lexical_cast       ALIAS Boost::lexical_cast)
     endif ()
 endif ()
 

--- a/thirdparty/external_boost_deps.cmake
+++ b/thirdparty/external_boost_deps.cmake
@@ -26,6 +26,7 @@ find_package(boost_json               ${FIND_BOOST_PACKAGE_QUIET})
 find_package(boost_optional           ${FIND_BOOST_PACKAGE_QUIET})
 find_package(boost_variant            ${FIND_BOOST_PACKAGE_QUIET})
 find_package(boost_regex              ${FIND_BOOST_PACKAGE_QUIET})
+find_package(boost_lexical_cast       ${FIND_BOOST_PACKAGE_QUIET})
 
 if (boost_algorithm_FOUND AND
    boost_filesystem_FOUND AND
@@ -33,15 +34,17 @@ if (boost_algorithm_FOUND AND
    boost_json_FOUND AND
    boost_optional_FOUND AND
    boost_variant_FOUND AND boost_regex_FOUND)
-   imported_target_alias(boost_algorithm          ALIAS boost_algorithm)
-   imported_target_alias(boost_filesystem         ALIAS boost_filesystem)
-   imported_target_alias(boost_numeric_conversion ALIAS numeric_conversion)
-   imported_target_alias(boost_json               ALIAS boost_json)
-   imported_target_alias(boost_optional           ALIAS boost_optional)
-   imported_target_alias(boost_variant            ALIAS boost_variant)
-   imported_target_alias(boost_regex              ALIAS boost_regex)
+   imported_target_alias(boost_algorithm          ALIAS boost_algorithm::boost_algorithm)
+   imported_target_alias(boost_filesystem         ALIAS boost_filesystem::boost_filesystem)
+   imported_target_alias(boost_numeric_conversion ALIAS numeric_conversion::numeric_conversion)
+   imported_target_alias(boost_json               ALIAS boost_json::boost_json)
+   imported_target_alias(boost_optional           ALIAS boost_optional::boost_optional)
+   imported_target_alias(boost_variant            ALIAS boost_variant::boost_variant)
+   imported_target_alias(boost_regex              ALIAS boost_regex::boost_regex)
+   imported_target_alias(boost_lexical_cast       ALIAS boost_regex::lexical_cast)
+   
 else ()
-    find_package(Boost COMPONENTS system filesystem numeric_conversion json regex ${FIND_BOOST_PACKAGE_QUIET} REQUIRED)
+    find_package(Boost COMPONENTS system filesystem numeric_conversion json regex optional variant algorithm lexical_cast ${FIND_BOOST_PACKAGE_QUIET} REQUIRED)
 
     if (Boost_FOUND)
         imported_target_alias(boost_algorithm          ALIAS Boost::boost)
@@ -51,6 +54,7 @@ else ()
         imported_target_alias(boost_optional           ALIAS Boost::boost)
         imported_target_alias(boost_variant            ALIAS Boost::boost)
         imported_target_alias(boost_regex              ALIAS Boost::regex)
+        imported_target_alias(boost_lexical_cast       ALIAS boost_regex::lexical_cast)
     endif ()
 endif ()
 


### PR DESCRIPTION
In order to use Jinja2CPP with vcpkg it requires boost::lexical-cast library.

After this change it will be possible to use Jinja2CPP as vcpkg library as requested here #194 