### PR TITLE
Fixed cross-compilation for Android

### DIFF
--- a/thirdparty/internal_deps.cmake
+++ b/thirdparty/internal_deps.cmake
@@ -52,6 +52,7 @@ FetchContent_MakeAvailable(rapidjson)
 
 find_package(RapidJSON REQUIRED
              PATHS "${rapidjson_BINARY_DIR}"
+             NO_CMAKE_FIND_ROOT_PATH
              NO_DEFAULT_PATH)
 
 add_library(RapidJson INTERFACE)


### PR DESCRIPTION
We don't need to prepend Android build root, since we are finding RapidJson by absolute path